### PR TITLE
Implement hash table with linear probing for price level lookup

### DIFF
--- a/src/engine/order_book.cpp
+++ b/src/engine/order_book.cpp
@@ -152,11 +152,9 @@ auto OrderBook::removePriceLevel(models::PriceLevel *priceLevel) noexcept
   priceLevels_[slot] = nullptr;
   priceLevelAllocator_.free(priceLevel);
 
-  // Backward-shift deletion: shift displaced entries back to fill the gap
   auto next = (slot + 1) & models::PRICE_LEVEL_TABLE_MASK;
   while (priceLevels_[next]) {
     auto naturalSlot = getPriceIndex(priceLevels_[next]->price_);
-    // Check if entry at `next` belongs at or before `slot` in the probe chain
     bool needsShift;
     if (slot < next) {
       needsShift = (naturalSlot <= slot || naturalSlot > next);

--- a/src/engine/order_book.cpp
+++ b/src/engine/order_book.cpp
@@ -110,7 +110,7 @@ auto OrderBook::addPriceLevel(models::Side side, models::Price price) noexcept
       priceLevelAllocator_.alloc(side, price, OrderQueueAllocator);
   if (!newPriceLevel) [[unlikely]]
     return nullptr;
-  priceLevels_[getPriceIndex(price)] = newPriceLevel;
+  priceLevels_[findEmptySlot(price)] = newPriceLevel;
 
   if (!bestPriceLevel) {
     bestPriceLevel = newPriceLevel;
@@ -148,7 +148,27 @@ auto OrderBook::removePriceLevel(models::PriceLevel *priceLevel) noexcept
     }
     priceLevel->next_ = priceLevel->prev_ = nullptr;
   }
-  priceLevels_[getPriceIndex(priceLevel->price_)] = nullptr;
+  auto slot = findOccupiedSlot(priceLevel->price_);
+  priceLevels_[slot] = nullptr;
   priceLevelAllocator_.free(priceLevel);
+
+  // Backward-shift deletion: shift displaced entries back to fill the gap
+  auto next = (slot + 1) & models::PRICE_LEVEL_TABLE_MASK;
+  while (priceLevels_[next]) {
+    auto naturalSlot = getPriceIndex(priceLevels_[next]->price_);
+    // Check if entry at `next` belongs at or before `slot` in the probe chain
+    bool needsShift;
+    if (slot < next) {
+      needsShift = (naturalSlot <= slot || naturalSlot > next);
+    } else {
+      needsShift = (naturalSlot <= slot && naturalSlot > next);
+    }
+    if (needsShift) {
+      priceLevels_[slot] = priceLevels_[next];
+      priceLevels_[next] = nullptr;
+      slot = next;
+    }
+    next = (next + 1) & models::PRICE_LEVEL_TABLE_MASK;
+  }
 }
 } // namespace stockex::engine

--- a/src/engine/order_book.hpp
+++ b/src/engine/order_book.hpp
@@ -64,8 +64,8 @@ public:
                                      models::Side side, models::Price price,
                                      models::Quantity quantity) noexcept;
 
-  [[nodiscard]] auto getPriceIndex(models::Price price) const noexcept {
-    return price % models::MAX_PRICE_LEVELS;
+  [[nodiscard]] static auto getPriceIndex(models::Price price) noexcept {
+    return static_cast<std::size_t>(price) & models::PRICE_LEVEL_TABLE_MASK;
   }
 
   [[nodiscard]] auto getOrder(models::OrderId orderId) const noexcept
@@ -75,12 +75,24 @@ public:
 
   [[nodiscard]] auto getPriceLevel(models::Price price) const noexcept
       -> const models::PriceLevel * {
-    return priceLevels_[getPriceIndex(price)];
+    auto idx = getPriceIndex(price);
+    for (std::size_t i = 0; i < models::PRICE_LEVEL_TABLE_SIZE; ++i) {
+      auto slot = (idx + i) & models::PRICE_LEVEL_TABLE_MASK;
+      if (!priceLevels_[slot]) return nullptr;
+      if (priceLevels_[slot]->price_ == price) return priceLevels_[slot];
+    }
+    return nullptr;
   }
 
   [[nodiscard]] auto getPriceLevel(models::Price price) noexcept
       -> models::PriceLevel * {
-    return priceLevels_[getPriceIndex(price)];
+    auto idx = getPriceIndex(price);
+    for (std::size_t i = 0; i < models::PRICE_LEVEL_TABLE_SIZE; ++i) {
+      auto slot = (idx + i) & models::PRICE_LEVEL_TABLE_MASK;
+      if (!priceLevels_[slot]) return nullptr;
+      if (priceLevels_[slot]->price_ == price) return priceLevels_[slot];
+    }
+    return nullptr;
   }
 
 private:
@@ -102,6 +114,27 @@ private:
 
   auto releaseOrderId(models::OrderId id) noexcept -> void {
     freeList_.push_back(id);
+  }
+
+  [[nodiscard]] auto findEmptySlot(models::Price price) noexcept
+      -> std::size_t {
+    auto idx = getPriceIndex(price);
+    for (std::size_t i = 0; i < models::PRICE_LEVEL_TABLE_SIZE; ++i) {
+      auto slot = (idx + i) & models::PRICE_LEVEL_TABLE_MASK;
+      if (!priceLevels_[slot]) return slot;
+    }
+    __builtin_unreachable();
+  }
+
+  [[nodiscard]] auto findOccupiedSlot(models::Price price) noexcept
+      -> std::size_t {
+    auto idx = getPriceIndex(price);
+    for (std::size_t i = 0; i < models::PRICE_LEVEL_TABLE_SIZE; ++i) {
+      auto slot = (idx + i) & models::PRICE_LEVEL_TABLE_MASK;
+      if (priceLevels_[slot] && priceLevels_[slot]->price_ == price)
+        return slot;
+    }
+    __builtin_unreachable();
   }
 
   auto addPriceLevel(models::Side side, models::Price price) noexcept

--- a/src/engine/order_book.hpp
+++ b/src/engine/order_book.hpp
@@ -73,25 +73,29 @@ public:
     return orders_[orderId];
   }
 
-  [[nodiscard]] auto getPriceLevel(models::Price price) const noexcept
-      -> const models::PriceLevel * {
-    auto idx = getPriceIndex(price);
-    for (std::size_t i = 0; i < models::PRICE_LEVEL_TABLE_SIZE; ++i) {
-      auto slot = (idx + i) & models::PRICE_LEVEL_TABLE_MASK;
-      if (!priceLevels_[slot]) return nullptr;
-      if (priceLevels_[slot]->price_ == price) return priceLevels_[slot];
+  [[nodiscard]] auto getPriceLevel(models::Price price) noexcept
+      -> models::PriceLevel * {
+    auto slot = getPriceIndex(price);
+
+    while (priceLevels_[slot]) {
+      if (priceLevels_[slot]->price_ == price)
+        return priceLevels_[slot];
+      slot = (slot + 1) & models::PRICE_LEVEL_TABLE_MASK;
     }
+
     return nullptr;
   }
 
-  [[nodiscard]] auto getPriceLevel(models::Price price) noexcept
-      -> models::PriceLevel * {
-    auto idx = getPriceIndex(price);
-    for (std::size_t i = 0; i < models::PRICE_LEVEL_TABLE_SIZE; ++i) {
-      auto slot = (idx + i) & models::PRICE_LEVEL_TABLE_MASK;
-      if (!priceLevels_[slot]) return nullptr;
-      if (priceLevels_[slot]->price_ == price) return priceLevels_[slot];
+  [[nodiscard]] auto getPriceLevel(models::Price price) const noexcept
+      -> const models::PriceLevel * {
+    auto slot = getPriceIndex(price);
+
+    while (priceLevels_[slot]) {
+      if (priceLevels_[slot]->price_ == price)
+        return priceLevels_[slot];
+      slot = (slot + 1) & models::PRICE_LEVEL_TABLE_MASK;
     }
+
     return nullptr;
   }
 
@@ -118,23 +122,24 @@ private:
 
   [[nodiscard]] auto findEmptySlot(models::Price price) noexcept
       -> std::size_t {
-    auto idx = getPriceIndex(price);
-    for (std::size_t i = 0; i < models::PRICE_LEVEL_TABLE_SIZE; ++i) {
-      auto slot = (idx + i) & models::PRICE_LEVEL_TABLE_MASK;
-      if (!priceLevels_[slot]) return slot;
+    auto slot = getPriceIndex(price);
+
+    while (priceLevels_[slot]) {
+      slot = (slot + 1) & models::PRICE_LEVEL_TABLE_MASK;
     }
-    __builtin_unreachable();
+
+    return slot;
   }
 
-  [[nodiscard]] auto findOccupiedSlot(models::Price price) noexcept
+  [[nodiscard]] auto findOccupiedSlot(models::Price price) const noexcept
       -> std::size_t {
-    auto idx = getPriceIndex(price);
-    for (std::size_t i = 0; i < models::PRICE_LEVEL_TABLE_SIZE; ++i) {
-      auto slot = (idx + i) & models::PRICE_LEVEL_TABLE_MASK;
-      if (priceLevels_[slot] && priceLevels_[slot]->price_ == price)
-        return slot;
+    auto slot = getPriceIndex(price);
+
+    while (!priceLevels_[slot] || priceLevels_[slot]->price_ != price) {
+      slot = (slot + 1) & models::PRICE_LEVEL_TABLE_MASK;
     }
-    __builtin_unreachable();
+
+    return slot;
   }
 
   auto addPriceLevel(models::Side side, models::Price price) noexcept

--- a/src/models/constants.hpp
+++ b/src/models/constants.hpp
@@ -21,6 +21,10 @@ constexpr std::size_t MAX_NUM_ORDERS = 25'000'000;
 /// Maximum price level depth in the order books.
 constexpr std::size_t MAX_PRICE_LEVELS = 1000;
 
+/// Hash table size for price level lookup (power-of-2, must be > MAX_PRICE_LEVELS).
+constexpr std::size_t PRICE_LEVEL_TABLE_SIZE = 2048;
+constexpr std::size_t PRICE_LEVEL_TABLE_MASK = PRICE_LEVEL_TABLE_SIZE - 1;
+
 constexpr std::size_t MAX_MATCH_EVENTS = 1000;
 
 constexpr std::size_t QUEUE_CHUNK_SIZE = 3072;

--- a/src/models/constants.hpp
+++ b/src/models/constants.hpp
@@ -21,7 +21,8 @@ constexpr std::size_t MAX_NUM_ORDERS = 25'000'000;
 /// Maximum price level depth in the order books.
 constexpr std::size_t MAX_PRICE_LEVELS = 1000;
 
-/// Hash table size for price level lookup (power-of-2, must be > MAX_PRICE_LEVELS).
+/// Hash table size for price level lookup (power-of-2, must be >
+/// MAX_PRICE_LEVELS).
 constexpr std::size_t PRICE_LEVEL_TABLE_SIZE = 2048;
 constexpr std::size_t PRICE_LEVEL_TABLE_MASK = PRICE_LEVEL_TABLE_SIZE - 1;
 

--- a/src/models/price_level.hpp
+++ b/src/models/price_level.hpp
@@ -64,5 +64,5 @@ struct OrderInfo {
   QueueHandle queueHandle_{};
   models::Price price_{models::INVALID_PRICE};
 };
-using PriceLevelMap = std::array<PriceLevel *, MAX_PRICE_LEVELS>;
+using PriceLevelMap = std::array<PriceLevel *, PRICE_LEVEL_TABLE_SIZE>;
 } // namespace stockex::models

--- a/tests/order_book_test.cpp
+++ b/tests/order_book_test.cpp
@@ -242,7 +242,6 @@ TEST_F(OrderBookTest, RemoveInRangeButUnusedIdReturnsError) {
 }
 
 TEST_F(OrderBookTest, AddOrdersWithCollidingPrices) {
-  // 100 and 2148 both hash to slot 100 (& 0x7FF)
   auto id1 = AddOrderAndVerify(1, BUY, 100, 50);
   auto id2 = AddOrderAndVerify(1, BUY, 2148, 30);
   EXPECT_NE(id1, id2);
@@ -276,7 +275,6 @@ TEST_F(OrderBookTest, RemoveSecondCollidingPrice) {
 }
 
 TEST_F(OrderBookTest, ThreeWayCollisionRemoveMiddle) {
-  // 100, 2148, and 4196 all hash to slot 100
   AddOrderAndVerify(1, BUY, 100, 50);
   auto id2 = AddOrderAndVerify(1, BUY, 2148, 30);
   AddOrderAndVerify(1, BUY, 4196, 20);

--- a/tests/order_book_test.cpp
+++ b/tests/order_book_test.cpp
@@ -241,4 +241,53 @@ TEST_F(OrderBookTest, RemoveInRangeButUnusedIdReturnsError) {
   EXPECT_EQ(result.error(), OrderBookError::InvalidOrderId);
 }
 
+TEST_F(OrderBookTest, AddOrdersWithCollidingPrices) {
+  // 100 and 2148 both hash to slot 100 (& 0x7FF)
+  auto id1 = AddOrderAndVerify(1, BUY, 100, 50);
+  auto id2 = AddOrderAndVerify(1, BUY, 2148, 30);
+  EXPECT_NE(id1, id2);
+  auto *pl1 = getOrderBook()->getPriceLevel(100);
+  auto *pl2 = getOrderBook()->getPriceLevel(2148);
+  ASSERT_NE(pl1, nullptr);
+  ASSERT_NE(pl2, nullptr);
+  EXPECT_EQ(pl1->price_, 100);
+  EXPECT_EQ(pl2->price_, 2148);
+  EXPECT_NE(pl1, pl2);
+}
+
+TEST_F(OrderBookTest, RemoveFirstCollidingPrice) {
+  auto id1 = AddOrderAndVerify(1, BUY, 100, 50);
+  AddOrderAndVerify(1, BUY, 2148, 30);
+  EXPECT_TRUE(getOrderBook()->removeOrder(id1).has_value());
+  EXPECT_EQ(getOrderBook()->getPriceLevel(100), nullptr);
+  auto *pl2 = getOrderBook()->getPriceLevel(2148);
+  ASSERT_NE(pl2, nullptr);
+  EXPECT_EQ(pl2->price_, 2148);
+}
+
+TEST_F(OrderBookTest, RemoveSecondCollidingPrice) {
+  AddOrderAndVerify(1, BUY, 100, 50);
+  auto id2 = AddOrderAndVerify(1, BUY, 2148, 30);
+  EXPECT_TRUE(getOrderBook()->removeOrder(id2).has_value());
+  EXPECT_EQ(getOrderBook()->getPriceLevel(2148), nullptr);
+  auto *pl1 = getOrderBook()->getPriceLevel(100);
+  ASSERT_NE(pl1, nullptr);
+  EXPECT_EQ(pl1->price_, 100);
+}
+
+TEST_F(OrderBookTest, ThreeWayCollisionRemoveMiddle) {
+  // 100, 2148, and 4196 all hash to slot 100
+  AddOrderAndVerify(1, BUY, 100, 50);
+  auto id2 = AddOrderAndVerify(1, BUY, 2148, 30);
+  AddOrderAndVerify(1, BUY, 4196, 20);
+  EXPECT_TRUE(getOrderBook()->removeOrder(id2).has_value());
+  EXPECT_EQ(getOrderBook()->getPriceLevel(2148), nullptr);
+  auto *pl1 = getOrderBook()->getPriceLevel(100);
+  auto *pl3 = getOrderBook()->getPriceLevel(4196);
+  ASSERT_NE(pl1, nullptr);
+  ASSERT_NE(pl3, nullptr);
+  EXPECT_EQ(pl1->price_, 100);
+  EXPECT_EQ(pl3->price_, 4196);
+}
+
 } // namespace stockex::engine


### PR DESCRIPTION
## Summary
Replace the direct modulo-based price level indexing with a proper hash table implementation using linear probing. This allows the order book to handle hash collisions correctly when multiple prices hash to the same slot.

## Key Changes

- **Hash table implementation**: Changed from direct indexing (`price % MAX_PRICE_LEVELS`) to a power-of-2 sized hash table (2048 entries) with linear probing for collision resolution
  - Updated `getPriceIndex()` to use bitwise AND with `PRICE_LEVEL_TABLE_MASK` instead of modulo
  - Made `getPriceIndex()` static since it no longer depends on instance state

- **Lookup with collision handling**: Modified `getPriceLevel()` methods (both const and non-const) to probe through the hash table linearly until finding the matching price or an empty slot

- **Insertion**: Updated `addPriceLevel()` to use `findEmptySlot()` helper to locate the first available slot in the probe chain

- **Deletion with backward-shift**: Implemented backward-shift deletion in `removePriceLevel()` to maintain hash table invariants:
  - Finds the occupied slot containing the price to remove
  - Shifts subsequent entries back to fill the gap if they belong earlier in their probe chain
  - Ensures future lookups can still find all entries

- **Helper methods**: Added `findEmptySlot()` and `findOccupiedSlot()` to encapsulate the linear probing logic

- **Constants**: Added `PRICE_LEVEL_TABLE_SIZE` (2048) and `PRICE_LEVEL_TABLE_MASK` (2047) to support the new hash table size

## Testing
Added comprehensive test cases covering:
- Hash collisions with two prices hashing to the same slot
- Removal of first and second colliding prices
- Three-way collisions with removal of the middle entry

https://claude.ai/code/session_01CqGKF3cDxf6YtC6knMa2kh